### PR TITLE
update release github action

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -2,8 +2,10 @@ name: build-docker-image
 
 on:
   push:
-    branches:
-      - 'main'
+    # This GitHub action creates a release when a tag that matches the pattern
+    # "v*" (e.g. v0.1.0) is created.
+    tags:
+      - 'v*'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -38,11 +40,13 @@ jobs:
           registry: "us-docker.pkg.dev"
           username: "oauth2accesstoken"
           password: "${{ steps.auth.outputs.access_token }}"
-      - name: Build and push
-        uses: docker/build-push-action@v4
+      - uses: actions/setup-go@v4
         with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.PUBLIC_REGISTRY }}/pvn-wrapper:latest
-            ${{ env.PUBLIC_REGISTRY }}/pvn-wrapper:${{ github.sha }}
+          go-version: 1.20
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,12 +4,13 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    flags:
+    - -trimpath
     main: ./cmd/pvn-wrapper
     goos:
       - linux
       - windows
       - darwin
-archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
@@ -22,3 +23,46 @@ release:
     owner: prodvana
     name: pvn-wrapper
   mode: replace
+
+dockers:
+  - dockerfile: "build_template.docker"
+    use: buildx
+    skip_push: true
+    image_templates:
+      - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-amd64"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--platform=linux/amd64"
+  - dockerfile: "build_template.docker"
+    use: buildx
+    skip_push: true
+    image_templates:
+      - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-arm64"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--platform=linux/arm64"
+docker_manifests:
+- name_template: "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:latest"
+  image_templates:
+  - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-amd64"
+  - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-arm64"
+- name_template: "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}"
+  image_templates:
+  - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-amd64"
+  - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-arm64"
+- name_template: "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:v{{ .Major }}"
+  image_templates:
+  - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-amd64"
+  - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-arm64"
+- name_template: "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:v{{ .Major }}.{{ .Minor }}"
+  image_templates:
+  - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-amd64"
+  - "us-docker.pkg.dev/pvn-infra/pvn-public/pvn-wrapper:{{ .Tag }}-arm64"

--- a/build_template.docker
+++ b/build_template.docker
@@ -1,0 +1,3 @@
+FROM scratch
+ENTRYPOINT ["/pvn-wrapper"]
+COPY pvn-wrapper /

--- a/cmd/pvn-wrapper/root.go
+++ b/cmd/pvn-wrapper/root.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/prodvana/pvn-wrapper/cmd/pvn-wrapper/terraform"
 	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 var rootCmd = &cobra.Command{
@@ -16,6 +23,8 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(terraform.RootCmd)
+	rootCmd.Version = version
+	rootCmd.SetVersionTemplate(fmt.Sprintf("{{.Version}} (%s %s)", commit, date))
 }
 
 func main() {

--- a/cmd/pvn-wrapper/root.go
+++ b/cmd/pvn-wrapper/root.go
@@ -24,7 +24,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(terraform.RootCmd)
 	rootCmd.Version = version
-	rootCmd.SetVersionTemplate(fmt.Sprintf("{{.Version}} (%s %s)", commit, date))
+	rootCmd.SetVersionTemplate(fmt.Sprintf("{{ .Version }} (%s %s)\n", commit, date))
 }
 
 func main() {


### PR DESCRIPTION
Release action now uses goreleaser to both build the go binaries as well
as the docker images.
