### PR TITLE
ignore creds file from gcp action so goreleaser doesn't complain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist/
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
Error:
```
  ⨯ release failed after 0s                  error=git is in a dirty state
Please check in your pipeline what can be changing the following files:
?? gha-creds-3721d630718c7519.json
```
